### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This assumes a local Ingres DBMS, a new database named `plugins` will be used.
     createdb plugins
     backupapps /reload /dbname plugins
     w4gldev makeimage plugins scripted_plugins scripted_plugins.plb -f -e -w -Tall
-    copy scripted_plugins.plb %II_W4GLAPPS_SYS%
+    copy scripted_plugins.plb "%II_W4GLAPPS_SYS%"
 
 NOTE this loads all applications found in the current directory.
 


### PR DESCRIPTION
Added quotes around II_W4GLAPPS_SYS so that copy command won't report an error when the directory name contains spaces.